### PR TITLE
fix: 修复多选模式下选择选项后搜索输入清空的问题

### DIFF
--- a/frontend/src/params-config/components/InputParamsValue/index.tsx
+++ b/frontend/src/params-config/components/InputParamsValue/index.tsx
@@ -70,8 +70,10 @@ export const InputParamsValue: React.FC<InputParamsValueProps> = (props) => {
   );
   const rootRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<any>(null);
+  const justSelected = useRef(false);
   const [value, setValue] = useState<string | string[]>(defaultValue);
   const [inputValue, setInputValue] = useState<string | string[]>('');
+  const [lastSearch, setLastSearch] = useState<string>('');
   const [popupVisible, setPopupVisible] = useState<boolean>(false);
   const [isEditing, setIsEditing] = useState(false);
 
@@ -198,13 +200,30 @@ export const InputParamsValue: React.FC<InputParamsValueProps> = (props) => {
           mode={enterFrom === 'batch-input' ? 'multiple' : undefined}
           defaultValue={defaultValue}
           value={value ? (value instanceof Array ? value : [value]) : []}
+          inputValue={inputValue as string}
           onChange={(v) => {
             setValue(v);
+            justSelected.current = true;
+            setTimeout(() => {
+              justSelected.current = false;
+            }, 0);
             if (enterFrom === 'single-input') {
               handleChange(v);
+            } else {
+              // Restore last search after multi-select
+              setInputValue(lastSearch);
             }
           }}
-          onInputValueChange={setInputValue}
+          onInputValueChange={(val) => {
+            if (val === '' && justSelected.current) {
+              // Ignore clear if due to selection
+              return;
+            }
+            setInputValue(val);
+            if (val) {
+              setLastSearch(val);
+            }
+          }}
           popupVisible={popupVisible}
           allowCreate={{
             formatter: (input_value) => ({


### PR DESCRIPTION
### 修复多选模式下选择选项后搜索输入清空的问题

#### 问题描述
在 `InputParamsValue` 组件中使用 Arco Design 的 `Select` 组件时，当处于多选模式（`mode: 'multiple'`）下，选择一个选项后，搜索输入框会自动清空。这在选项列表非常多的情况下，会导致用户不便：用户需要反复输入相同的搜索词来选择相似项，影响使用体验。

#### 解决方案
通过以下修改来解决：
- 添加 `justSelected` ref 来检测输入清空是否由于选择事件触发。
- 引入 `lastSearch` state 来记录最后一个非空搜索词。
- 在 `onChange` 中设置 `justSelected` 标志，并在多选模式下恢复 `lastSearch` 到输入框。
- 修改 `onInputValueChange` 以忽略选择后的自动清空事件，并保持搜索词。

这些变更使搜索词在选择选项后得以保留，过滤列表保持不变，便于连续选择类似项。同时，确保单选模式和输入控制逻辑不受影响。

#### 修改文件
- `InputParamsValue.tsx`：添加了相关 state、ref 和逻辑处理（详见代码 diff）。

#### 测试步骤
1. 在批输入模式（`enterFrom: 'batch-input'`）下，使用带有大量选项的 `Select` 组件。
2. 输入搜索词，过滤选项。
3. 选择一个选项，验证搜索输入未清空，过滤列表保持。
4. 继续选择其他选项，确认体验顺畅。
5. 测试单选模式，确保无回归问题。

此修复不引入新依赖，兼容现有代码。如果有任何反馈，欢迎讨论！