### PR TITLE
Fix asyncio event loop conflicts in package recovery and task completion hooks

### DIFF
--- a/lumi_batcher_service/controller/package/recover.py
+++ b/lumi_batcher_service/controller/package/recover.py
@@ -2,22 +2,53 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import asyncio
 import traceback
+from functools import partial
 from lumi_batcher_service.handler.batch_tools import BatchToolsHandler
 from .package import execute_package_batch_task
+
+
+def _on_recover_task_done(task: asyncio.Task, batch_task_id: str):
+    try:
+        task.result()
+    except Exception as e:
+        print(f"recover package task failed, batch_task_id={batch_task_id}: {e}")
+        traceback.print_exc()
+
+
+async def _recover_package_without_running_loop(
+    batchToolsHandler: BatchToolsHandler, batch_task_ids: list[str]
+):
+    for batch_task_id in batch_task_ids:
+        await execute_package_batch_task(batchToolsHandler, batch_task_id)
 
 
 def recover_package(batchToolsHandler: BatchToolsHandler):
     try:
         # 查询所有打包未完成的任务
         batchTaskList = batchToolsHandler.batchTaskDao.get_unpackage_list()
+        batch_task_ids = []
         for batchTask in batchTaskList:
             batch_task_id = batchTask.get("id", "")
-            if batch_task_id == "":
-                continue
-            loop = asyncio.new_event_loop()
-            loop.run_until_complete(
-                execute_package_batch_task(batchToolsHandler, batch_task_id)
+            if batch_task_id != "":
+                batch_task_ids.append(batch_task_id)
+
+        if len(batch_task_ids) == 0:
+            return
+
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(
+                _recover_package_without_running_loop(batchToolsHandler, batch_task_ids)
             )
+        else:
+            for batch_task_id in batch_task_ids:
+                task = running_loop.create_task(
+                    execute_package_batch_task(batchToolsHandler, batch_task_id)
+                )
+                task.add_done_callback(
+                    partial(_on_recover_task_done, batch_task_id=batch_task_id)
+                )
     except Exception as e:
         print(e)
         traceback.print_exc()

--- a/lumi_batcher_service/hooks/task_done.py
+++ b/lumi_batcher_service/hooks/task_done.py
@@ -84,6 +84,38 @@ def resolve_messages(messages) -> tuple:
         )
 
 
+def _on_package_task_done(task: asyncio.Task, batch_task_id: str):
+    try:
+        task.result()
+    except Exception as e:
+        print(f"package task failed, batch_task_id={batch_task_id}: {e}")
+        traceback.print_exc()
+
+
+def run_or_schedule_package_task(
+    batchToolsHandler: BatchToolsHandler, batch_task_id: str
+):
+    try:
+        running_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(
+                execute_package_batch_task(batchToolsHandler, batch_task_id)
+            )
+        finally:
+            loop.close()
+    else:
+        task = running_loop.create_task(
+            execute_package_batch_task(batchToolsHandler, batch_task_id)
+        )
+        task.add_done_callback(
+            lambda t, batch_task_id=batch_task_id: _on_package_task_done(
+                t, batch_task_id
+            )
+        )
+
+
 def batch_tools_task_done_hook(batchToolsHandler: BatchToolsHandler):
     @monkey_patch_class_decorator(execution.PromptQueue, "task_done")
     def overwrite_task_done(origin_fn: Callable, self, *args, **kwargs):
@@ -217,11 +249,8 @@ def batch_tools_task_done_hook(batchToolsHandler: BatchToolsHandler):
                             CommonTaskStatus.PARTIAL_SUCCESS.value,
                             CommonTaskStatus.CANCELLED.value,
                         ]:
-                            loop = asyncio.new_event_loop()
-                            loop.run_until_complete(
-                                execute_package_batch_task(
-                                    batchToolsHandler, batch_task_id
-                                )
+                            run_or_schedule_package_task(
+                                batchToolsHandler, batch_task_id
                             )
 
         except Exception as e:


### PR DESCRIPTION
## Summary
This PR fixes startup/runtime errors caused by calling `run_until_complete` while ComfyUI’s event loop is already running.

## Problem
The plugin could raise:

`RuntimeError: Cannot run the event loop while another loop is running`

This happened when:
- recovering unfinished package tasks during module import
- triggering package creation in `task_done` hook

It also caused follow-up warnings like un-awaited coroutine warnings in failure paths.

## Root Cause
The code created new event loops and called `run_until_complete(...)` in contexts where an asyncio loop may already be active (inside ComfyUI async initialization / runtime flow).