### PR TITLE
fix: 修复 zip 图片包解压后文件顺序不正确的问题

### DIFF
--- a/lumi_batcher_service/common/resolve_file.py
+++ b/lumi_batcher_service/common/resolve_file.py
@@ -4,6 +4,8 @@ import io
 import os
 import pandas
 import zipfile
+
+from natsort import natsorted
 from .file import copyFile, get_file_absolute_path, find_comfyui_dir
 
 
@@ -142,6 +144,7 @@ class ResolveFileManager:
                         audio_file.write(audio_data)
                         res.append(file_name)
 
+        res = natsorted(res)
         return res
 
     def resolve_single_file(self, path) -> list[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pandas==2.2.0",
     "aiofiles==23.2.1",
     "filetype==1.2.0",
+    "natsort>=8.4.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ openpyxl>=2.6.0
 pandas>=0.25.0
 aiofiles>=0.8.0
 filetype>=1.0.0
+natsort>=8.4.0


### PR DESCRIPTION
使用 natsort 对 zip 包内的文件名进行自然排序，确保文件顺序与 xlsx 表格行顺序对应。

例如 image1.jpg, image2.jpg, ..., image10.jpg 按正确顺序排列， 而非字符串排序。

Fixes #79 